### PR TITLE
Do not strip executables

### DIFF
--- a/do-not-strip-executables.patch
+++ b/do-not-strip-executables.patch
@@ -1,0 +1,25 @@
+From c6b86e087e652b1a5ee0f2a3aaad90281086a4e3 Mon Sep 17 00:00:00 2001
+From: "Steven A. Falco" <stevenfalco@gmail.com>
+Date: Tue, 12 May 2020 11:16:34 -0400
+Subject: [PATCH] Do not strip executables
+
+---
+ CMakeLists.txt | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 962fa3e80..ae8eee493 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -358,8 +358,6 @@ if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+         set( CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined" )
+         set( CMAKE_MODULE_LINKER_FLAGS "-Wl,--no-undefined" )
+
+-        set( CMAKE_EXE_LINKER_FLAGS_RELEASE "-s" )
+-
+         # Defeat ELF's ability to use the GOT to replace locally implemented functions
+         # with ones from another module.
+         # https://bugs.launchpad.net/kicad/+bug/1322354
+--
+2.26.2
+

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -142,6 +142,7 @@ modules:
 - name: kicad
   buildsystem: cmake-ninja
   config-opts:
+  - -DCMAKE_BUILD_TYPE=Release
   - -DGLEW_INCLUDE_DIR=/app/include/GL
   - -DOCC_INCLUDE_DIR=/app/include/opencascade
   - -DOPENGL_glu_LIBRARY=/app/lib/libGLU.so
@@ -156,6 +157,8 @@ modules:
   - type: archive
     url: https://gitlab.com/kicad/code/kicad/-/archive/5.1.9/kicad-5.1.9.tar.gz
     sha256: 841be864b9dc5c761193c3ee9cbdbed6729952d7b38451aa8e1977bdfdb6081b
+  - type: patch
+    path: do-not-strip-executables.patch
   - type: patch
     path: fix-rectifier-demo-for-ngspice-32.patch
   - type: patch


### PR DESCRIPTION
This fixes the issue with the .Debug extension not containing debug
symbols before.

Patch by Steven A. Falco taken from Fedora package.