### PR TITLE
Update wxPython to 4.1.1

### DIFF
--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -62,14 +62,16 @@ modules:
     sha256: aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a
 
 - name: wxWidgets
-  rm-configure: true
   cleanup:
   - /bin
+  config-opts:
+  - --with-opengl
+  rm-configure: true
   subdir: ext/wxWidgets
   sources:
   - type: archive
-    url: https://files.pythonhosted.org/packages/b9/8b/31267dd6d026a082faed35ec8d97522c0236f2e083bf15aff64d982215e1/wxPython-4.0.7.post2.tar.gz
-    sha256: 5a229e695b64f9864d30a5315e0c1e4ff5e02effede0a07f16e8d856737a0c4e
+    url: https://files.pythonhosted.org/packages/b0/4d/80d65c37ee60a479d338d27a2895fb15bbba27a3e6bb5b6d72bb28246e99/wxPython-4.1.1.tar.gz
+    sha256: 00e5e3180ac7f2852f342ad341d57c44e7e4326de0b550b9a5c4a8361b6c3528
   - type: script
     commands:
     - cp -p /usr/share/automake-*/config.{sub,guess} .

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -65,6 +65,7 @@ modules:
   cleanup:
   - /bin
   config-opts:
+  - --disable-glcanvasegl
   - --with-opengl
   rm-configure: true
   subdir: ext/wxWidgets

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -19,5 +19,5 @@ modules:
     url: https://files.pythonhosted.org/packages/60/f0/dd2eb7911f948bf529f58f0c7931f6f6466f711bd6f1d81a69dc4edd4e2a/Pillow-8.1.2.tar.gz
     sha256: b07c660e014852d98a00a91adfbe25033898a9d90a8f39beb2437d22a203fc44
   - type: file
-    url: https://files.pythonhosted.org/packages/b9/8b/31267dd6d026a082faed35ec8d97522c0236f2e083bf15aff64d982215e1/wxPython-4.0.7.post2.tar.gz
-    sha256: 5a229e695b64f9864d30a5315e0c1e4ff5e02effede0a07f16e8d856737a0c4e
+    url: https://files.pythonhosted.org/packages/b0/4d/80d65c37ee60a479d338d27a2895fb15bbba27a3e6bb5b6d72bb28246e99/wxPython-4.1.1.tar.gz
+    sha256: 00e5e3180ac7f2852f342ad341d57c44e7e4326de0b550b9a5c4a8361b6c3528


### PR DESCRIPTION
Keeping this open as a draft for people to build locally.

It was decided that the official KiCad flatpak will stay on wxPython 4.0.x/wxWidgets 3.0.x during the remainder of the KiCad 5.1.x branch. The stable KiCad flatpak will switch to wxPython 4.1.x/wxWidgets 3.1.x with the release of version 6.0.