### PR TITLE
Patch kicad-pcb.org to kicad.org to fix TLS errors

### DIFF
--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -162,6 +162,7 @@ modules:
     paths:
     - patches/do-not-strip-executables.patch
     - patches/rename-icons-mime-and-desktop-files-for-flatpak.patch
+    - patches/kicad-pcb.org-kicad.org-in-kicad.appdata.xml.in.patch
   - type: shell
     commands:
     - sed -i '5s/org\.kicad_pcb\.kicad/org.kicad.KiCad/;96i<kudos><kudo>UserDocs</kudo></kudos>' resources/linux/appdata/kicad.appdata.xml.in

--- a/patches/kicad-pcb.org-kicad.org-in-kicad.appdata.xml.in.patch
+++ b/patches/kicad-pcb.org-kicad.org-in-kicad.appdata.xml.in.patch
@@ -1,0 +1,57 @@
+From ee4a8fc05a7ffd4864f851bbf15837d55ae12aa1 Mon Sep 17 00:00:00 2001
+From: Johannes Maibaum <jmaibaum@gmail.com>
+Date: Mon, 18 Oct 2021 22:19:34 +0200
+Subject: [PATCH] kicad-pcb.org->kicad.org in kicad.appdata.xml.in
+
+kicad-pcb.org seems to cause TLS handshake errors recently.
+As kicad.org is now the official domain, switch all uses of
+kicad-pcb.org to kicad.org in kicad.appdata.xml.in.
+---
+ resources/linux/appdata/kicad.appdata.xml.in | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/resources/linux/appdata/kicad.appdata.xml.in b/resources/linux/appdata/kicad.appdata.xml.in
+index f50c4183c3..f604ca8df1 100644
+--- a/resources/linux/appdata/kicad.appdata.xml.in
++++ b/resources/linux/appdata/kicad.appdata.xml.in
+@@ -67,29 +67,29 @@
+ 
+   <screenshots>
+     <screenshot type="default">
+-      <image width="1290" height="825">https://kicad-pcb.org/img/screenshots/appstream/kicad.png</image>
++      <image width="1290" height="825">https://kicad.org/img/screenshots/appstream/kicad.png</image>
+     </screenshot>
+ 
+     <screenshot>
+       <caption>Eeschema Schematic Editor</caption>
+-      <image width="1290" height="825">https://kicad-pcb.org/img/screenshots/appstream/eeschema.png</image>
++      <image width="1290" height="825">https://kicad.org/img/screenshots/appstream/eeschema.png</image>
+     </screenshot>
+ 
+     <screenshot>
+       <caption>PcbNew PCB Layout</caption>
+-      <image width="1290" height="825">https://kicad-pcb.org/img/screenshots/appstream/pcbnew.png</image>
++      <image width="1290" height="825">https://kicad.org/img/screenshots/appstream/pcbnew.png</image>
+     </screenshot>
+ 
+     <screenshot>
+       <caption>PcbNew 3D Viewer</caption>
+-      <image width="1290" height="825">https://kicad-pcb.org/img/screenshots/appstream/3dviewer.png</image>
++      <image width="1290" height="825">https://kicad.org/img/screenshots/appstream/3dviewer.png</image>
+     </screenshot>
+   </screenshots>
+ 
+-  <url type="homepage">https://kicad-pcb.org/</url>
+-  <url type="bugtracker">https://kicad-pcb.org/help/report-a-bug/</url>
+-  <url type="help">https://docs.kicad-pcb.org/</url>
+-  <url type="donation">https://kicad-pcb.org/</url>
++  <url type="homepage">https://kicad.org/</url>
++  <url type="bugtracker">https://kicad.org/help/report-a-bug/</url>
++  <url type="help">https://docs.kicad.org/</url>
++  <url type="donation">https://kicad.org/</url>
+ 
+   <update_contact>kicad-developers@lists.launchpad.net</update_contact>
+   <developer_name>The KiCad Developers</developer_name>
+-- 
+2.31.1
+


### PR DESCRIPTION
kicad-pcb.org seems to cause TLS handshake errors recently.
As kicad.org is now the official domain, switch all uses of
kicad-pcb.org to kicad.org in kicad.appdata.xml.in.