### PR TITLE
Remove OCCT related config-opts from KiCad build

### DIFF
--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -178,8 +178,6 @@ modules:
       - -DKICAD_BUILD_QA_TESTS=OFF
       - -DKICAD_BUILD_I18N=ON
       - -DKICAD_USE_EGL=OFF
-      - -DKICAD_USE_OCC=ON
-      - -DKICAD_USE_OCE=OFF
       - -DKICAD_LIBRARY_DATA=/app/extensions/Library
     post-install:
       - for f in $FLATPAK_DEST/share/applications/*.desktop; do desktop_name="$(basename


### PR DESCRIPTION
* KICAD_USE_OCE is obsolete
* KICAD_USE_OCC is active by default

So, no need to specify them anymore.