### PR TITLE
Fix x-checker-data for boost

### DIFF
--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -104,7 +104,7 @@ modules:
         x-checker-data:
           type: html
           url: https://www.boost.org/users/download/
-          version-pattern: Version ([\d\.]+)
+          version-pattern: Version (\d+\.?\d+\.\d+)(?!\sbeta)|</a>$
           url-template: https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${version0}_${version1}_${version2}.tar.gz
 
   - name: wxWidgets


### PR DESCRIPTION
The previous pattern was matching '1.80.0' in '1.80.0 beta 1',
resulting in a 404 error trying to download this yet unreleased version.