### PR TITLE
Remove LD_LIBRARY_PATH override

### DIFF
--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -6,7 +6,6 @@ command: kicad
 rename-appdata-file: org.kicad.kicad.metainfo.xml
 finish-args:
   - --device=dri
-  - --env=LD_LIBRARY_PATH=/app/lib
   - --filesystem=home
   - --share=ipc
   - --share=network


### PR DESCRIPTION
It seems that this is no longer needed to find libngspice.