### PR TITLE
Python requests dependency juggling

### DIFF
--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -13,14 +13,12 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl
-    sha256: 83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
+    url: https://files.pythonhosted.org/packages/ef/81/14b3b8f01ddaddad6cdec97f2f599aa2fa466bd5ee9af99b08b7713ccd29/charset_normalizer-3.1.0-py3-none-any.whl
+    sha256: 3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d
     x-checker-data:
       name: charset_normalizer
       packagetype: bdist_wheel
       type: pypi
-      versions:
-        <: '3'
   - type: file
     url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl
     sha256: 90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2

--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -40,3 +40,5 @@ sources:
       name: urllib3
       packagetype: bdist_wheel
       type: pypi
+      versions:
+        <: '2'


### PR DESCRIPTION
- Update to charset_normalizer 3.1.0 (supported since requests 2.28.2)
- Keep urllib3 at 1.x.x (see https://github.com/psf/requests/issues/6432)