### PR TITLE
Fix crash reported against kicad-cli

### DIFF
--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -139,6 +139,10 @@ modules:
         commands:
           - cp -p /usr/share/automake-*/config.{sub,guess} .
           - autoconf -f -B build/autoconf_prepend-include
+      - type: patch
+        paths:
+          # The following will be included in wx 3.2.4, once released
+          - patches/0001-Avoid-crash-with-GTK3-if-console-program-is-linked-to-GUI.patch
 
   - python3-wxPython.yml
   - python3-requests.yml

--- a/patches/0001-Avoid-crash-with-GTK3-if-console-program-is-linked-to-GUI.patch
+++ b/patches/0001-Avoid-crash-with-GTK3-if-console-program-is-linked-to-GUI.patch
@@ -1,0 +1,38 @@
+From 14445658555dc52e3a700e58f8a30295ffdfb2dd Mon Sep 17 00:00:00 2001
+From: Paul Cornett <paulcor@users.noreply.github.com>
+Date: Sat, 21 Oct 2023 09:20:45 -0700
+Subject: [PATCH] Avoid crash with GTK3 if console program is linked to GUI
+ library
+
+A console program should not really be linked with the GUI library, but it used
+to work, and it's unavoidable with the monolithic build, so fix the regression.
+See #23981
+
+(cherry picked from commit 4cabfa111ab5912ae30d6d44b917a9c403845b3f)
+---
+ src/gtk/settings.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/gtk/settings.cpp b/src/gtk/settings.cpp
+index 32a16734a9fa..91e5520fde7d 100644
+--- a/src/gtk/settings.cpp
++++ b/src/gtk/settings.cpp
+@@ -13,6 +13,7 @@
+ #include "wx/settings.h"
+ 
+ #ifndef WX_PRECOMP
++    #include "wx/app.h"
+     #include "wx/toplevel.h"
+     #include "wx/module.h"
+ #endif
+@@ -1210,6 +1211,10 @@ bool wxSystemSettingsModule::OnInit()
+ 
+     m_proxy = NULL;
+ 
++    wxAppConsole* app = wxAppConsole::GetInstance();
++    if (!app || !app->IsGUI())
++        return true;
++
+     // GTK_THEME environment variable overrides other settings
+     if (getenv("GTK_THEME") == NULL)
+     {

--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -13,8 +13,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/a3/dc/efab5b27839f04be4b8058c1eb85b7ab7dbc55ef8067250bea0518392756/charset_normalizer-3.3.0-py3-none-any.whl
-    sha256: e46cd37076971c1040fc8c41273a8b3e2c624ce4f2be3f5dfcb7a430c1d3acc2
+    url: https://files.pythonhosted.org/packages/22/ac/70f41edd03346a23df001e67daffebbf74cb0ab2d2347725d633efa6d379/charset_normalizer-3.3.1-py3-none-any.whl
+    sha256: 800561453acdecedaac137bf09cd719c7a440b6800ec182f077bb8e7025fb708
     x-checker-data:
       name: charset_normalizer
       packagetype: bdist_wheel


### PR DESCRIPTION
See:
* https://gitlab.com/kicad/code/kicad/-/issues/15974
* https://github.com/wxWidgets/wxWidgets/issues/23981

(Also add pending dependency updates for glu and charset_normalizer)