### PR TITLE
beta: KiCad 7.0.10-rc1

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -3,8 +3,7 @@ modules:
   - name: perl-build
     buildsystem: simple
     build-commands:
-      - perl Build.PL --install_base=${FLATPAK_DEST}
-                      --install_path lib=${FLATPAK_DEST}/lib
+      - perl Build.PL --install_base=${FLATPAK_DEST} --install_path lib=${FLATPAK_DEST}/lib
       - ./Build code
       - ./Build install
     cleanup:
@@ -17,7 +16,8 @@ modules:
           type: html
           url: https://metacpan.org/dist/Module-Build
           url-template: https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-$version.tar.gz
-          version-pattern: Module-Build-([\d\.]+) - Build and install Perl modules - metacpan.org
+          version-pattern: Module-Build-([\d\.]+) - Build and install Perl modules
+            - metacpan.org
 
   - name: perl-pod-parser
     buildsystem: simple
@@ -35,7 +35,8 @@ modules:
           type: html
           url: https://metacpan.org/dist/Pod-Parser
           url-template: https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Parser-$version.tar.gz
-          version-pattern: Pod-Parser-([\d\.]+) - Modules for parsing/translating POD format documents - metacpan.org
+          version-pattern: Pod-Parser-([\d\.]+) - Modules for parsing/translating
+            POD format documents - metacpan.org
 
   - name: perl-yaml-tiny
     buildsystem: simple
@@ -53,7 +54,8 @@ modules:
           type: html
           url: https://metacpan.org/dist/YAML-Tiny
           url-template: https://cpan.metacpan.org/authors/id/E/ET/ETHER/YAML-Tiny-$version.tar.gz
-          version-pattern: YAML-Tiny-([\d\.]+) - Read/Write YAML files with as little code as possible - metacpan.org
+          version-pattern: YAML-Tiny-([\d\.]+) - Read/Write YAML files with as little
+            code as possible - metacpan.org
 
   - name: perl-mime-charset
     buildsystem: simple
@@ -71,7 +73,8 @@ modules:
           type: html
           url: https://metacpan.org/dist/MIME-Charset
           url-template: https://cpan.metacpan.org/authors/id/N/NE/NEZUMI/MIME-Charset-$version.tar.gz
-          version-pattern: MIME-Charset-([\d\.]+) - Charset Information for MIME - metacpan.org
+          version-pattern: MIME-Charset-([\d\.]+) - Charset Information for MIME -
+            metacpan.org
 
   - name: perl-unicode-gcstring
     buildsystem: simple
@@ -91,7 +94,8 @@ modules:
           type: html
           url: https://metacpan.org/dist/Unicode-LineBreak
           url-template: https://cpan.metacpan.org/authors/id/N/NE/NEZUMI/Unicode-LineBreak-$version.tar.gz
-          version-pattern: Unicode-LineBreak-([\d\.]+) - UAX \#14 Unicode Line Breaking Algorithm - metacpan.org
+          version-pattern: Unicode-LineBreak-([\d\.]+) - UAX \#14 Unicode Line Breaking
+            Algorithm - metacpan.org
 
   - name: po4a
     buildsystem: simple
@@ -99,8 +103,7 @@ modules:
       env:
         PERL5LIB: /app/lib
     build-commands:
-      - perl Build.PL --install_base=${FLATPAK_DEST}
-                      --install_path lib=${FLATPAK_DEST}/lib
+      - perl Build.PL --install_base=${FLATPAK_DEST} --install_path lib=${FLATPAK_DEST}/lib
       - ./Build code
       - ./Build install
     cleanup:
@@ -121,9 +124,8 @@ modules:
       env:
         GEM_PATH: /app/lib/ruby/gems/2.7.1
     build-commands:
-      - gem install --ignore-dependencies --no-user-install --verbose
-                    --local --install-dir ${FLATPAK_DEST}/lib/ruby/gems/2.7.1
-                    --bindir ${FLATPAK_DEST}/bin *.gem
+      - gem install --ignore-dependencies --no-user-install --verbose --local --install-dir
+        ${FLATPAK_DEST}/lib/ruby/gems/2.7.1 --bindir ${FLATPAK_DEST}/bin *.gem
     cleanup:
       - '*'
     sources:
@@ -147,8 +149,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: e84a56f8b443d11d9ae4de8f6daa9ba1fc2caa3a
-        tag: 7.0.9
+        commit: 8d8e1bb95b1e4852d4fedbc85187245f370ed181
+        tag: 7.0.10
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -111,8 +111,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz
-        sha256: c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628
+        url: https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.gz
+        sha256: a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724
         x-checker-data:
           type: html
           url: https://www.boost.org/users/download/
@@ -246,8 +246,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: ec99e10b31684b146a3ecd1deeec5493395b8e26
-        tag: 7.0.9-rc2
+        commit: bf184804b238e0b25fa3a01819e9b7182cd9736f
+        tag: 7.0.10-rc1
         x-checker-data:
           is-main-source: true
           type: git

--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -6,22 +6,22 @@ build-commands:
     --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/4c/dd/2234eab22353ffc7d94e8d13177aaa050113286e93e7b40eae01fbf7c3d9/certifi-2023.7.22-py3-none-any.whl
-    sha256: 92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
+    url: https://files.pythonhosted.org/packages/64/62/428ef076be88fa93716b576e4a01f919d25968913e817077a386fcbe4f42/certifi-2023.11.17-py3-none-any.whl
+    sha256: e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474
     x-checker-data:
       name: certifi
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/22/ac/70f41edd03346a23df001e67daffebbf74cb0ab2d2347725d633efa6d379/charset_normalizer-3.3.1-py3-none-any.whl
-    sha256: 800561453acdecedaac137bf09cd719c7a440b6800ec182f077bb8e7025fb708
+    url: https://files.pythonhosted.org/packages/28/76/e6222113b83e3622caa4bb41032d0b1bf785250607392e1b778aca0b8a7d/charset_normalizer-3.3.2-py3-none-any.whl
+    sha256: 3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc
     x-checker-data:
       name: charset_normalizer
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl
-    sha256: 90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
+    url: https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl
+    sha256: c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
     x-checker-data:
       name: idna
       packagetype: bdist_wheel
@@ -35,8 +35,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/d2/b2/b157855192a68541a91ba7b2bbcb91f1b4faa51f8bae38d8005c034be524/urllib3-2.0.7-py3-none-any.whl
-    sha256: fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e
+    url: https://files.pythonhosted.org/packages/96/94/c31f58c7a7f470d5665935262ebd7455c7e4c7782eb525658d3dbf4b9403/urllib3-2.1.0-py3-none-any.whl
+    sha256: 55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3
     x-checker-data:
       name: urllib3
       packagetype: bdist_wheel

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -29,8 +29,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/OpenMathLib/OpenBLAS
-        tag: v0.3.24
-        commit: 9f815cf1bf16b4e64d4aee681b33558fc090b62a
+        tag: v0.3.25
+        commit: 5e1a429eab44731b6668b8f6043c1ea951b0a80b
         x-checker-data:
           type: git
           tag-pattern: ^(v[\d\.]+)$
@@ -72,8 +72,8 @@ modules:
         --prefix=${FLATPAK_DEST} numpy --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/78/23/f78fd8311e0f710fe1d065d50b92ce0057fe877b8ed7fd41b28ad6865bfc/numpy-1.26.1.tar.gz
-        sha256: c8c6c72d4a9f831f328efb1312642a1cafafaa88981d9ab76368d50d07d93cbe
+        url: https://files.pythonhosted.org/packages/dd/2b/205ddff2314d4eea852e31d53b8e55eb3f32b292efc3dd86bd827ab9019d/numpy-1.26.2.tar.gz
+        sha256: f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea
         x-checker-data:
           type: pypi
           name: numpy


### PR DESCRIPTION
Update boost_1_83_0.tar.gz to 1.84.0
Update kicad.git to 7.0.10-rc1
Update OpenBLAS to v0.3.25
Update numpy-1.26.1.tar.gz to 1.26.2
Update certifi-2023.7.22-py3-none-any.whl to 2023.11.17 Update charset_normalizer-3.3.1-py3-none-any.whl to 3.3.2 Update idna-3.4-py3-none-any.whl to 3.6
Update urllib3-2.0.7-py3-none-any.whl to 2.1.0
Update kicad-doc.git to 7.0.10