### PR TITLE
beta: Update 6 modules

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -29,8 +29,8 @@ modules:
       - '*'
     sources:
       - type: archive
-        url: https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Parser-1.66.tar.gz
-        sha256: 22928a7bffe61b452c05bbbb8f5216d4b9cf9fe2a849b776c25500d24d20df7c
+        url: https://cpan.metacpan.org/authors/id/M/MA/MAREKR/Pod-Parser-1.67.tar.gz
+        sha256: 5deccbf55d750ce65588cd211c1a03fa1ef3aaa15d1ac2b8d85383a42c1427ea
         x-checker-data:
           type: html
           url: https://metacpan.org/dist/Pod-Parser

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -148,8 +148,8 @@ modules:
       - /share
     sources:
       - type: archive
-        url: https://sourceforge.net/projects/swig/files/swig/swig-4.1.1/swig-4.1.1.tar.gz
-        sha256: 2af08aced8fcd65cdb5cc62426768914bedc735b1c250325203716f78e39ac9b
+        url: https://sourceforge.net/projects/swig/files/swig/swig-4.2.0/swig-4.2.0.tar.gz
+        sha256: 261ca2d7589e260762817b912c075831572b72ff2717942f75b3e51244829c97
         x-checker-data:
           type: html
           url: https://www.swig.org/download.html
@@ -170,8 +170,8 @@ modules:
     rm-configure: true
     sources:
       - type: archive
-        url: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/41/ngspice-41.tar.gz
-        sha256: 1ce219395d2f50c33eb223a1403f8318b168f1e6d1015a7db9dbf439408de8c4
+        url: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/42/ngspice-42.tar.gz
+        sha256: 737fe3846ab2333a250dfadf1ed6ebe1860af1d8a5ff5e7803c772cc4256e50a
         x-checker-data:
           is-important: true
           type: html

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -29,8 +29,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/OpenMathLib/OpenBLAS
-        tag: v0.3.25
-        commit: 5e1a429eab44731b6668b8f6043c1ea951b0a80b
+        tag: v0.3.26
+        commit: 6c77e5e314474773a7749357b153caba4ec3817d
         x-checker-data:
           type: git
           tag-pattern: ^(v[\d\.]+)$
@@ -72,8 +72,8 @@ modules:
         --prefix=${FLATPAK_DEST} numpy --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/dd/2b/205ddff2314d4eea852e31d53b8e55eb3f32b292efc3dd86bd827ab9019d/numpy-1.26.2.tar.gz
-        sha256: f65738447676ab5777f11e6bbbdb8ce11b785e105f690bc45966574816b6d3ea
+        url: https://files.pythonhosted.org/packages/d0/b0/13e2b50c95bfc1d5ee04925eb5c105726c838f922d0aaddd57b7c8be0f8b/numpy-1.26.3.tar.gz
+        sha256: 697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4
         x-checker-data:
           type: pypi
           name: numpy
@@ -90,8 +90,8 @@ modules:
       - /bin
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/80/d7/c4b258c9098b469c4a4e77b0a99b5f4fd21e359c2e486c977d231f52fc71/Pillow-10.1.0.tar.gz
-        sha256: e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38
+        url: https://files.pythonhosted.org/packages/f8/3e/32cbd0129a28686621434cbf17bb64bf1458bfb838f1f668262fefce145c/pillow-10.2.0.tar.gz
+        sha256: e87f0b2c78157e12d7686b27d63c070fd65d994e8ddae6f328e0dcf4a0cd007e
         x-checker-data:
           type: pypi
           name: Pillow


### PR DESCRIPTION
Update swig-4.1.1.tar.gz to 4.2.0
Update ngspice-41.tar.gz to 42
Update OpenBLAS to v0.3.26
Update numpy-1.26.2.tar.gz to 1.26.3
Update Pillow-10.1.0.tar.gz to 10.2.0
Update Pod-Parser-1.66.tar.gz to 1.67