### PR TITLE
beta: Update 2 modules (KiCad 8.0.0-rc2)

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -149,8 +149,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: 810b0fd96af338bc1c0f94a5c4cc5c6d4f56e9c9
-        tag: 8.0.0-rc1
+        commit: 4164076507699b46d7cc5bbf7a3e665d9e1d7b79
+        tag: 8.0.0-rc2
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -266,8 +266,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: 7461b4c7201ead27200d7837d65c00c7a70a9155
-        tag: 8.0.0-rc1
+        commit: ebb69bdfa42a2753f1bb1fc27aee3ea312cb6182
+        tag: 8.0.0-rc2
         x-checker-data:
           is-main-source: true
           type: git


### PR DESCRIPTION
Update kicad.git to 8.0.0-rc2
Update kicad-doc.git to 8.0.0-rc2