### PR TITLE
beta: Update 5 modules

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -110,8 +110,8 @@ modules:
       - '*'
     sources:
       - type: archive
-        url: https://github.com/mquinson/po4a/releases/download/v0.69/po4a-0.69.tar.gz
-        sha256: 7cd4aff13661665ec2d9df478757ae407683d4ecb5c2627ccf8b46729bcb9496
+        url: https://github.com/mquinson/po4a/releases/download/v0.70/po4a-0.70.tar.gz
+        sha256: 9e27bdb12d8beaf840b2732def767d282d070c8e77e63a9baf807057411509b3
         x-checker-data:
           type: html
           url: https://po4a.org

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -209,8 +209,8 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: git
-        commit: a2bde63741977ca0f4ef7db2f609df320be67a08
-        tag: v1.7.1
+        commit: a418d9d4ab87bae16b87d8f37143a4687ae0e4b2
+        tag: v1.7.2
         url: https://github.com/libgit2/libgit2
         x-checker-data:
           type: git

--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -6,8 +6,8 @@ build-commands:
     --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/64/62/428ef076be88fa93716b576e4a01f919d25968913e817077a386fcbe4f42/certifi-2023.11.17-py3-none-any.whl
-    sha256: e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474
+    url: https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl
+    sha256: dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
     x-checker-data:
       name: certifi
       packagetype: bdist_wheel
@@ -35,8 +35,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/96/94/c31f58c7a7f470d5665935262ebd7455c7e4c7782eb525658d3dbf4b9403/urllib3-2.1.0-py3-none-any.whl
-    sha256: 55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3
+    url: https://files.pythonhosted.org/packages/88/75/311454fd3317aefe18415f04568edc20218453b709c63c58b9292c71be17/urllib3-2.2.0-py3-none-any.whl
+    sha256: ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224
     x-checker-data:
       name: urllib3
       packagetype: bdist_wheel

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -72,8 +72,8 @@ modules:
         --prefix=${FLATPAK_DEST} numpy --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/d0/b0/13e2b50c95bfc1d5ee04925eb5c105726c838f922d0aaddd57b7c8be0f8b/numpy-1.26.3.tar.gz
-        sha256: 697df43e2b6310ecc9d95f05d5ef20eacc09c7c4ecc9da3f235d39e71b7da1e4
+        url: https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz
+        sha256: 2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010
         x-checker-data:
           type: pypi
           name: numpy

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -39,7 +39,7 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} attrdict3 packaging pyproject_metadata --no-build-isolation
+        --prefix=${FLATPAK_DEST} attrdict3 meson_python packaging pyproject_metadata --no-build-isolation
     cleanup:
       - /lib
     sources:
@@ -50,6 +50,13 @@ modules:
           type: pypi
           packagetype: bdist_wheel
           name: attrdict3
+      - type: file
+        url: https://files.pythonhosted.org/packages/1f/60/b10b11ab470a690d5777310d6cfd1c9bdbbb0a1313a78c34a1e82e0b9d27/meson_python-0.15.0-py3-none-any.whl
+        sha256: 3ae38253ff02b2e947a05e362a2eaf5a9a09d133c5666b4123399ee5fbf2e591
+        x-checker-data:
+          type: pypi
+          packagetype: bdist_wheel
+          name: meson-python
       - type: file
         url: https://files.pythonhosted.org/packages/ec/1a/610693ac4ee14fcdf2d9bf3c493370e4f2ef7ae2e19217d7a237ff42367d/packaging-23.2-py3-none-any.whl
         sha256: 8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7


### PR DESCRIPTION
Update libgit2 to v1.7.2
Update numpy-1.26.3.tar.gz to 1.26.4
Update certifi-2023.11.17-py3-none-any.whl to 2024.2.2
Update urllib3-2.1.0-py3-none-any.whl to 2.2.0
Update po4a-0.69.tar.gz to 0.70