### PR TITLE
beta: Update 2 modules (update to KiCad 8.0.0-rc3)

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -149,8 +149,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: 4164076507699b46d7cc5bbf7a3e665d9e1d7b79
-        tag: 8.0.0-rc2
+        commit: 9def88bfacf628403eec9ed44111ff92a4404ab7
+        tag: 8.0.0-rc3
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -266,8 +266,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: ebb69bdfa42a2753f1bb1fc27aee3ea312cb6182
-        tag: 8.0.0-rc2
+        commit: afae6e2e9d9d9575fa6154174933eb3a0c61b7b7
+        tag: 8.0.0-rc3
         x-checker-data:
           is-main-source: true
           type: git


### PR DESCRIPTION
Update kicad.git to 8.0.0-rc3
Update kicad-doc.git to 8.0.0-rc3