### PR TITLE
beta: Update 4 modules (KiCad v8.0.1-rc2)

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -130,8 +130,8 @@ modules:
       - '*'
     sources:
       - type: file
-        url: https://rubygems.org/gems/asciidoctor-2.0.21.gem
-        sha256: 07138c69d2aa320932d38beb17fedb09090cdb38e64d14c1f6926b620715c100
+        url: https://rubygems.org/gems/asciidoctor-2.0.22.gem
+        sha256: a6d8f1bb593a3617c0334fdf36b1e25186c4f4d0e15636538c5811de9bb1cad6
         x-checker-data:
           type: html
           url: https://rubygems.org/gems/asciidoctor
@@ -149,8 +149,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: 51419bc2cbfae0adf22d83ffc535e372d19f4347
-        tag: 8.0.1-rc1
+        commit: e44e21aa5841e528a73c9f85e4b3a38c41bad915
+        tag: 8.0.1-rc2
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -269,8 +269,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: fa2ccdd083e3d244562a372dd04905fcb87cebfa
-        tag: 8.0.1-rc1
+        commit: b7a193dc3a44f3611d0768007f04059c65234639
+        tag: 8.0.1-rc2
         x-checker-data:
           is-main-source: true
           type: git

--- a/python3-pytest.yml
+++ b/python3-pytest.yml
@@ -22,8 +22,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/5a/4a/3f626e3974bea1e6d471bd86f7965c67cd06d5770d1fec9aae445c44da7b/pytest-8.1.0-py3-none-any.whl
-    sha256: ee32db7af8de4629a455806befa90559f307424c07b8413ccfc30bf5b221dd7e
+    url: https://files.pythonhosted.org/packages/4d/7e/c79cecfdb6aa85c6c2e3cf63afc56d0f165f24f5c66c03c695c4d9b84756/pytest-8.1.1-py3-none-any.whl
+    sha256: 2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7
     x-checker-data:
       name: pytest
       packagetype: bdist_wheel


### PR DESCRIPTION
Update kicad.git to 8.0.1-rc2
Update pytest-8.1.0-py3-none-any.whl to 8.1.1
Update asciidoctor-2.0.21.gem to 2.0.22
Update kicad-doc.git to 8.0.1-rc2