### PR TITLE
beta: Update 5 modules (KiCad v8.0.2-rc2)

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -149,8 +149,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: 210cee654f8b2e810b114b3aa2a283eb47cb8c15
-        tag: 8.0.2-rc1
+        commit: 97d048cf53f5d579f39aeffad9435f21771f4c06
+        tag: 8.0.2-rc2
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -65,8 +65,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.freedesktop.org/xorg/lib/libxmu.git
-        tag: libXmu-1.2.0
-        commit: cc378e4f0cc2ab5b66d378050ba4956612a01197
+        tag: libXmu-1.2.1
+        commit: 792f80402ee06ce69bca3a8f2a84295999c3a170
         x-checker-data:
           type: git
           tag-pattern: ^libXmu-([\d\.]+)$
@@ -269,8 +269,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: e03308e5ca83034411d73a14b9d60416ebb1b668
-        tag: 8.0.2-rc1
+        commit: 3517d25aec343e2904fa9b9a5ad669aa797b4d7b
+        tag: 8.0.2-rc2
         x-checker-data:
           is-main-source: true
           type: git

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -52,8 +52,8 @@ modules:
           packagetype: bdist_wheel
           name: attrdict3
       - type: file
-        url: https://files.pythonhosted.org/packages/1f/60/b10b11ab470a690d5777310d6cfd1c9bdbbb0a1313a78c34a1e82e0b9d27/meson_python-0.15.0-py3-none-any.whl
-        sha256: 3ae38253ff02b2e947a05e362a2eaf5a9a09d133c5666b4123399ee5fbf2e591
+        url: https://files.pythonhosted.org/packages/91/c0/104cb6244c83fe6bc3886f144cc433db0c0c78efac5dc00e409a5a08c87d/meson_python-0.16.0-py3-none-any.whl
+        sha256: 842dc9f5dc29e55fc769ff1b6fe328412fe6c870220fc321060a1d2d395e69e8
         x-checker-data:
           type: pypi
           packagetype: bdist_wheel
@@ -66,8 +66,8 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/c4/cb/4678dfd70cd2f2d8969e571cdc1bb1e9293c698f8d1cf428fadcf48d6e9f/pyproject_metadata-0.7.1-py3-none-any.whl
-        sha256: 28691fbb36266a819ec56c9fa1ecaf36f879d6944dfde5411e87fc4ff793aa60
+        url: https://files.pythonhosted.org/packages/aa/5f/bb5970d3d04173b46c9037109f7f05fc8904ff5be073ee49bb6ff00301bc/pyproject_metadata-0.8.0-py3-none-any.whl
+        sha256: ad858d448e1d3a1fb408ac5bac9ea7743e7a8bbb472f2693aaa334d2db42f526
         x-checker-data:
           name: pyproject-metadata
           packagetype: bdist_wheel


### PR DESCRIPTION
Update libxmu.git to 1.2.1
Update kicad.git to 8.0.2-rc2
Update meson_python-0.15.0-py3-none-any.whl to 0.16.0
Update pyproject_metadata-0.7.1-py3-none-any.whl to 0.8.0
Update kicad-doc.git to 8.0.2-rc2