### PR TITLE
Update 11 modules (KiCad v8.0.2)

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -149,8 +149,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: b472e528a4e3399eb8627e00f27aa0d04715f602
-        tag: 8.0.1
+        commit: 3fe9b8ef7378032cfc72637b1c6ade54b061f62d
+        tag: 8.0.2
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -64,8 +64,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.freedesktop.org/xorg/lib/libxmu.git
-        tag: libXmu-1.2.0
-        commit: cc378e4f0cc2ab5b66d378050ba4956612a01197
+        tag: libXmu-1.2.1
+        commit: 792f80402ee06ce69bca3a8f2a84295999c3a170
         x-checker-data:
           type: git
           tag-pattern: ^libXmu-([\d\.]+)$
@@ -113,8 +113,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.gz
-        sha256: a5800f405508f5df8114558ca9855d2640a2de8f0445f051fa1c7c3383045724
+        url: https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.gz
+        sha256: be0d91732d5b0cc6fbb275c7939974457e79b54d6f07ce2e3dfdd68bef883b0b
         x-checker-data:
           type: html
           url: https://www.boost.org/users/download/
@@ -217,7 +217,7 @@ modules:
           type: git
           tag-pattern: ^(v[\d\.]+)$
           versions:
-            <: 'v1.8.0'
+            <: v1.8.0
 
   - python3-pytest.yml
 
@@ -272,8 +272,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: ac408046cfde7a273ff267bed0cfd03cdfa6075e
-        tag: 8.0.1
+        commit: 61a17e4c8b944da0d34a7eec9eaffe4f343fa11f
+        tag: 8.0.2
         x-checker-data:
           is-main-source: true
           type: git

--- a/python3-pytest.yml
+++ b/python3-pytest.yml
@@ -15,15 +15,15 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/a5/5b/0cc789b59e8cc1bf288b38111d002d8c5917123194d45b29dcdac64723cc/pluggy-1.4.0-py3-none-any.whl
-    sha256: 7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981
+    url: https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl
+    sha256: 44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
     x-checker-data:
       name: pluggy
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/4d/7e/c79cecfdb6aa85c6c2e3cf63afc56d0f165f24f5c66c03c695c4d9b84756/pytest-8.1.1-py3-none-any.whl
-    sha256: 2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7
+    url: https://files.pythonhosted.org/packages/c4/43/6b1debd95ecdf001bc46789a933f658da3f9738c65f32db3f4e8f2a4ca97/pytest-8.2.0-py3-none-any.whl
+    sha256: 1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233
     x-checker-data:
       name: pytest
       packagetype: bdist_wheel
@@ -35,8 +35,8 @@ sources:
       name: cffi
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/17/be/a5d2c16317c6a890502725970589ae7f06cfc66b2e6916ba0a86973403c8/cairocffi-1.6.1-py3-none-any.whl
-    sha256: aa78ee52b9069d7475eeac457389b6275aa92111895d78fbaa2202a52dac112e
+    url: https://files.pythonhosted.org/packages/4c/0d/c9b8a12971276b33143422ff6b73aa7d74cff5f7effbffbe2a1df3bd6590/cairocffi-1.7.0-py3-none-any.whl
+    sha256: 1f29a8d41dbda4090c0aa33bcdea64f3b493e95f74a43ea107c4a8a7b7f632ef
     x-checker-data:
       name: cairocffi
       packagetype: bdist_wheel
@@ -70,8 +70,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/da/99/fd23634d6962c2791fb8cb6ccae1f05dcbfc39bce36bba8b1c9a8d92eae8/tinycss2-1.2.1-py3-none-any.whl
-    sha256: 2b80a96d41e7c3914b8cda8bc7f705a4d9c49275616e886103dd839dfc847847
+    url: https://files.pythonhosted.org/packages/2c/4d/0db5b8a613d2a59bbc29bc5bb44a2f8070eb9ceab11c50d477502a8a0092/tinycss2-1.3.0-py3-none-any.whl
+    sha256: 54a8dbdffb334d536851be0226030e9505965bb2f30f21a4a82c55fb2a80fae7
     x-checker-data:
       name: tinycss2
       packagetype: bdist_wheel

--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -20,8 +20,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/c2/e7/a82b05cf63a603df6e68d59ae6a68bf5064484a0718ea5033660af4b54a9/idna-3.6-py3-none-any.whl
-    sha256: c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
+    url: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
+    sha256: 82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
     x-checker-data:
       name: idna
       packagetype: bdist_wheel

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -52,8 +52,8 @@ modules:
           packagetype: bdist_wheel
           name: attrdict3
       - type: file
-        url: https://files.pythonhosted.org/packages/1f/60/b10b11ab470a690d5777310d6cfd1c9bdbbb0a1313a78c34a1e82e0b9d27/meson_python-0.15.0-py3-none-any.whl
-        sha256: 3ae38253ff02b2e947a05e362a2eaf5a9a09d133c5666b4123399ee5fbf2e591
+        url: https://files.pythonhosted.org/packages/91/c0/104cb6244c83fe6bc3886f144cc433db0c0c78efac5dc00e409a5a08c87d/meson_python-0.16.0-py3-none-any.whl
+        sha256: 842dc9f5dc29e55fc769ff1b6fe328412fe6c870220fc321060a1d2d395e69e8
         x-checker-data:
           type: pypi
           packagetype: bdist_wheel
@@ -66,8 +66,8 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/c4/cb/4678dfd70cd2f2d8969e571cdc1bb1e9293c698f8d1cf428fadcf48d6e9f/pyproject_metadata-0.7.1-py3-none-any.whl
-        sha256: 28691fbb36266a819ec56c9fa1ecaf36f879d6944dfde5411e87fc4ff793aa60
+        url: https://files.pythonhosted.org/packages/aa/5f/bb5970d3d04173b46c9037109f7f05fc8904ff5be073ee49bb6ff00301bc/pyproject_metadata-0.8.0-py3-none-any.whl
+        sha256: ad858d448e1d3a1fb408ac5bac9ea7743e7a8bbb472f2693aaa334d2db42f526
         x-checker-data:
           name: pyproject-metadata
           packagetype: bdist_wheel


### PR DESCRIPTION
Update libxmu.git to 1.2.1
Update boost_1_84_0.tar.gz to 1.85.0
Update kicad.git to 8.0.2
Update meson_python-0.15.0-py3-none-any.whl to 0.16.0
Update pyproject_metadata-0.7.1-py3-none-any.whl to 0.8.0
Update idna-3.6-py3-none-any.whl to 3.7
Update pluggy-1.4.0-py3-none-any.whl to 1.5.0
Update pytest-8.1.1-py3-none-any.whl to 8.2.0
Update cairocffi-1.6.1-py3-none-any.whl to 1.7.0
Update tinycss2-1.2.1-py3-none-any.whl to 1.3.0
Update kicad-doc.git to 8.0.2