### PR TITLE
beta: Update 6 modules (KiCad v8.0.3-rc1)

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -130,8 +130,8 @@ modules:
       - '*'
     sources:
       - type: file
-        url: https://rubygems.org/gems/asciidoctor-2.0.22.gem
-        sha256: a6d8f1bb593a3617c0334fdf36b1e25186c4f4d0e15636538c5811de9bb1cad6
+        url: https://rubygems.org/gems/asciidoctor-2.0.23.gem
+        sha256: 52208807f237dfa0ca29882f8b13d60b820496116ad191cf197ca56f2b7fddf3
         x-checker-data:
           type: html
           url: https://rubygems.org/gems/asciidoctor
@@ -149,8 +149,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: 97d048cf53f5d579f39aeffad9435f21771f4c06
-        tag: 8.0.2-rc2
+        commit: d1a5525acbb5a2238c69202ed9d1f3c484b23fc3
+        tag: 8.0.3-rc1
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -207,8 +207,8 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: git
-        commit: d74d491481831ddcd23575d376e56d2197e95910
-        tag: v1.8.0
+        commit: 36f7e21ad757a3dacc58cf7944329da6bc1d6e96
+        tag: v1.8.1
         url: https://github.com/libgit2/libgit2
         x-checker-data:
           type: git
@@ -267,8 +267,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: 3517d25aec343e2904fa9b9a5ad669aa797b4d7b
-        tag: 8.0.2-rc2
+        commit: be71f776ce034d63a4dc66a414a4c1eb87ecd511
+        tag: 8.0.3-rc1
         x-checker-data:
           is-main-source: true
           type: git

--- a/python3-pytest.yml
+++ b/python3-pytest.yml
@@ -22,8 +22,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/c4/43/6b1debd95ecdf001bc46789a933f658da3f9738c65f32db3f4e8f2a4ca97/pytest-8.2.0-py3-none-any.whl
-    sha256: 1733f0620f6cda4095bbf0d9ff8022486e91892245bb9e7d5542c018f612f233
+    url: https://files.pythonhosted.org/packages/b4/c1/27a1274b73712232328cb5115030057b7dec377f36a518c83f2e01d4f305/pytest-8.2.1-py3-none-any.whl
+    sha256: faccc5d332b8c3719f40283d0d44aa5cf101cec36f88cde9ed8f2bc0538612b1
     x-checker-data:
       name: pytest
       packagetype: bdist_wheel

--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -27,8 +27,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl
-    sha256: 58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
+    url: https://files.pythonhosted.org/packages/c3/20/748e38b466e0819491f0ce6e90ebe4184966ee304fe483e2c414b0f4ef07/requests-2.32.2-py3-none-any.whl
+    sha256: fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c
     x-checker-data:
       is-important: true
       name: requests


### PR DESCRIPTION
Update libgit2 to v1.8.1
Update kicad.git to 8.0.3-rc1
Update requests-2.31.0-py3-none-any.whl to 2.32.2
Update pytest-8.2.0-py3-none-any.whl to 8.2.1
Update asciidoctor-2.0.22.gem to 2.0.23
Update kicad-doc.git to 8.0.3-rc1