### PR TITLE
beta: ngspice: Allow dots in version pattern

### DIFF
--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -173,8 +173,8 @@ modules:
     rm-configure: true
     sources:
       - type: archive
-        url: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/44/ngspice-44.tar.gz
-        sha256: 3865d13ab44f1f01f68c7ac0e0716984e45dce5a86d126603c26d8df30161e9b
+        url: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/44.2/ngspice-44.2.tar.gz
+        sha256: e7dadfb7bd5474fd22409c1e5a67acdec19f77e597df68e17c5549bc1390d7fd
         x-checker-data:
           is-important: true
           type: html
@@ -230,8 +230,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/protocolbuffers/protobuf.git
-        tag: v29.2
-        commit: 233098326bc268fc03b28725c941519fc77703e6
+        tag: v29.3
+        commit: b407e8416e3893036aee5af9a12bd9b6a0e2b2e6
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -180,7 +180,7 @@ modules:
           type: html
           url: https://ngspice.sourceforge.io/download.html
           url-template: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/$version/ngspice-$version.tar.gz
-          version-pattern: <strong>ngspice-([\d]+)</strong>
+          version-pattern: <strong>ngspice-([\d.]+)</strong>
       - type: script
         commands:
           - cp -p /usr/share/automake-*/config.{sub,guess} .

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -29,8 +29,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/OpenMathLib/OpenBLAS
-        tag: v0.3.28
-        commit: 5ef8b1964658f9cb6a6324a06f6a1a022609b0c5
+        tag: v0.3.29
+        commit: 8795fc7985635de1ecf674b87e2008a15097ffab
         x-checker-data:
           type: git
           tag-pattern: ^(v[\d\.]+)$


### PR DESCRIPTION
Otherwise the new version 44.2 is rejected by f-e-d-c.