### PR TITLE
9.0.0 release: Change temp directory to /var/tmp, disable access to host /tmp

### DIFF
--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -6,11 +6,10 @@ command: kicad-startup
 finish-args:
   - --device=dri
   - --filesystem=home
-  # Required for default path of KiCad's IPC API
-  - --filesystem=/tmp:rw
   - --share=ipc
   - --share=network
   - --socket=x11
+  - --env=TMPDIR=/var/tmp
 
 add-extensions:
   org.kicad.KiCad.Library:


### PR DESCRIPTION
Background: see https://github.com/flathub/org.kicad.KiCad/pull/369#issuecomment-2673326831