### PR TITLE
beta: kicad 9.0.3-rc1, Update python3-requests, openblas and 4 more modules

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -149,8 +149,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: b88a402c263f436c71c7b0f7b55226ae2664e3ba
-        tag: 9.0.2-rc1
+        commit: 4a63302e377babad79c73aa35e75c76a65fe08db
+        tag: 9.0.3-rc1
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -309,8 +309,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: ad501536e8a0fe530cfa2fc47650339cd4ce0979
-        tag: 9.0.2-rc1
+        commit: 7182278200090f6b9713ad8e24bf3587c74d5d18
+        tag: 9.0.3-rc1
         x-checker-data:
           is-main-source: true
           type: git

--- a/python3-pytest.yml
+++ b/python3-pytest.yml
@@ -22,8 +22,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl
-    sha256: f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e
+    url: https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl
+    sha256: 539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7
     x-checker-data:
       name: pytest
       packagetype: bdist_wheel

--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -6,8 +6,8 @@ build-commands:
     --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl
-    sha256: 30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3
+    url: https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl
+    sha256: 2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057
     x-checker-data:
       name: certifi
       packagetype: bdist_wheel
@@ -27,16 +27,16 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl
-    sha256: 70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+    url: https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl
+    sha256: 27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c
     x-checker-data:
       is-important: true
       name: requests
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl
-    sha256: 4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
+    url: https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl
+    sha256: e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
     x-checker-data:
       name: urllib3
       packagetype: bdist_wheel

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -29,8 +29,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/OpenMathLib/OpenBLAS
-        tag: v0.3.29
-        commit: 8795fc7985635de1ecf674b87e2008a15097ffab
+        tag: v0.3.30
+        commit: 993fad6aebbce34a97d3f8c34d6d79d35b64cc48
         x-checker-data:
           type: git
           tag-pattern: ^(v[\d\.]+)$
@@ -80,8 +80,8 @@ modules:
         --prefix=${FLATPAK_DEST} numpy --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/f3/db/8e12381333aea300890829a0a36bfa738cac95475d88982d538725143fd9/numpy-2.3.0.tar.gz
-        sha256: 581f87f9e9e9db2cba2141400e160e9dd644ee248788d6f90636eeb8fd9260a6
+        url: https://files.pythonhosted.org/packages/2e/19/d7c972dfe90a353dbd3efbbe1d14a5951de80c99c9dc1b93cd998d51dc0f/numpy-2.3.1.tar.gz
+        sha256: 1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b
         x-checker-data:
           type: pypi
           name: numpy
@@ -93,8 +93,8 @@ modules:
         --prefix=${FLATPAK_DEST} pillow --no-build-isolation
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/af/cb/bb5c01fcd2a69335b86c22142b2bccfc3464087efb7fd382eee5ffc7fdf7/pillow-11.2.1.tar.gz
-        sha256: a64dd61998416367b7ef979b73d3a85853ba9bec4c2925f74e588879a58716b6
+        url: https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz
+        sha256: 3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523
         x-checker-data:
           type: pypi
           name: Pillow


### PR DESCRIPTION
kicad: Update kicad.git to 9.0.3-rc1
python3-requests: Update certifi-2025.4.26-py3-none-any.whl to 2025.6.15
python3-requests: Update requests-2.32.3-py3-none-any.whl to 2.32.4
python3-requests: Update urllib3-2.4.0-py3-none-any.whl to 2.5.0
openblas: Update OpenBLAS to v0.3.30
python3-numpy: Update numpy-2.3.0.tar.gz to 2.3.1
python3-pillow: Update pillow-11.2.1.tar.gz to 11.3.0
python3-pytest: Update pytest-8.4.0-py3-none-any.whl to 8.4.1
kicad-doc: Update kicad-doc.git to 9.0.3-rc1