### PR TITLE
beta: swig: Downgrade to v4.3.1

### DIFF
--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -150,13 +150,15 @@ modules:
       - /share
     sources:
       - type: archive
-        url: https://sourceforge.net/projects/swig/files/swig/swig-4.4.0/swig-4.4.0.tar.gz
-        sha256: c3f8e5dcd68c18aa19847b33b0a1bb92f07e904c53ae9cf5ae4ff8727a72927e
+        url: https://sourceforge.net/projects/swig/files/swig/swig-4.3.1/swig-4.3.1.tar.gz
+        sha256: 44fc829f70f1e17d635a2b4d69acab38896699ecc24aa023e516e0eabbec61b8
         x-checker-data:
           type: html
           url: https://www.swig.org/download.html
           version-pattern: The latest release is <a href=".+">swig-([\d\.]+)</a>
           url-template: https://sourceforge.net/projects/swig/files/swig/swig-$version/swig-$version.tar.gz
+          versions:
+            <: 4.4.0
 
   - name: ngspice
     cleanup:


### PR DESCRIPTION
swig 4.4.0 results Python plugins not loading due to in the following error:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/app/share/kicad/scripting/kicad_pyshell/__init__.py", line 23, in <module>
    import pcbnew
  File "/app/lib/python3.13/site-packages/pcbnew.py", line 68, in <module>
    class SwigPyIterator(object):
    ...<76 lines>...
            return self
  File "/app/lib/python3.13/site-packages/pcbnew.py", line 76, in SwigPyIterator
    __swig_destroy__ = _pcbnew.delete_SwigPyIterator
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'moduledef' object has no attribute 'delete_SwigPyIterator'
```