### PR TITLE
beta: kicad-10.0.4-rc1

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -172,8 +172,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: c59ba062eed41b6676990c2ea759037cbe3e5488
-        tag: 10.0.2-rc1
+        commit: ff59d8ecf799b8c11d61233738962ddc7f351f07
+        tag: 10.0.4-rc1
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -294,8 +294,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.freedesktop.org/poppler/poppler.git
-        commit: b0091f08803ffe7784e365db45abd003159bf45d
-        tag: poppler-26.05.0
+        commit: 1fe40984214a729350da11950fc7f09343247202
+        tag: poppler-26.06.0
         x-checker-data:
           type: git
           tag-pattern: ^poppler-([\d\.]+)$
@@ -354,8 +354,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: 895c0c3779c43e4c6b368d1596a735d25e27e108
-        tag: 10.0.2-rc1
+        commit: 2b47ef4f2e3accf12eaa783bb9c27034014215e6
+        tag: 10.0.4-rc1
         x-checker-data:
           is-main-source: true
           type: git

--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -20,8 +20,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl
-    sha256: cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5
+    url: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+    sha256: 7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
     x-checker-data:
       name: idna
       packagetype: bdist_wheel


### PR DESCRIPTION
poppler: Update poppler.git to 26.06.0
kicad: Update kicad.git to 10.0.4-rc1
python3-requests: Update idna-3.16-py3-none-any.whl to 3.18
kicad-doc: Update kicad-doc.git to 10.0.4-rc1