### PR TITLE
kicad-10.0.4: Update protobuf, poppler, kicad, python3-requests and 3 more modules

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -174,7 +174,7 @@ modules:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
         commit: ff59d8ecf799b8c11d61233738962ddc7f351f07
-        tag: 10.0.3
+        tag: 10.0.4
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -251,8 +251,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/protocolbuffers/protobuf.git
-        tag: v35.0
-        commit: e59364c38e10de3686a3305ff11fbfc59a10dbd8
+        tag: v35.1
+        commit: 35cd01f9fe9afbeea38cc7b979a3b6bfcde82c03
         x-checker-data:
           type: git
           tag-pattern: ^v([\d\.]+)$
@@ -293,8 +293,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.freedesktop.org/poppler/poppler.git
-        commit: b0091f08803ffe7784e365db45abd003159bf45d
-        tag: poppler-26.05.0
+        commit: 1fe40984214a729350da11950fc7f09343247202
+        tag: poppler-26.06.0
         x-checker-data:
           type: git
           tag-pattern: ^poppler-([\d\.]+)$
@@ -354,8 +354,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: 146a4f2a7585c65bc580427a19b6fe2ec4a3f622
-        tag: 10.0.3
+        commit: f7414d419cae5df2d00e7eaacb16fc0e803799bc
+        tag: 10.0.4
         x-checker-data:
           is-main-source: true
           type: git

--- a/python3-pytest.yml
+++ b/python3-pytest.yml
@@ -21,8 +21,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl
-    sha256: 2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9
+    url: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
+    sha256: 37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
     x-checker-data:
       name: pytest
       packagetype: bdist_wheel

--- a/python3-requests.yml
+++ b/python3-requests.yml
@@ -6,8 +6,8 @@ build-commands:
     --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
-    sha256: 3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897
+    url: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
+    sha256: 2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
     x-checker-data:
       name: certifi
       packagetype: bdist_wheel
@@ -20,8 +20,8 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl
-    sha256: cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5
+    url: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+    sha256: 7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
     x-checker-data:
       name: idna
       packagetype: bdist_wheel

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -50,8 +50,8 @@ modules:
       - /lib
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/16/7f/d1b0c65b267a1463d752b324f11d3470e30889daefc4b9ec83029bfa30b5/meson_python-0.19.0-py3-none-any.whl
-        sha256: 67b5906c37404396d23c195e12c8825506074460d4a2e7083266b845d14f0298
+        url: https://files.pythonhosted.org/packages/90/ad/77f9483e180cabab2772ac222aedd3dfab858e60d992f40414a3f08e7494/meson_python-0.20.0-py3-none-any.whl
+        sha256: 6a744cf0c09e76ecbdc58cfa374b48c8902dac1b74479628238634efbf36aec9
         x-checker-data:
           type: pypi
           packagetype: bdist_wheel


### PR DESCRIPTION
protobuf: Update protobuf.git to 35.1
poppler: Update poppler.git to 26.06.0
kicad: Update kicad.git to 10.0.4
python3-requests: Update certifi-2026.5.20-py3-none-any.whl to 2026.6.17
python3-requests: Update idna-3.16-py3-none-any.whl to 3.18
python3-build-dependencies: Update meson_python-0.19.0-py3-none-any.whl to 0.20.0
python3-pytest: Update pytest-9.0.3-py3-none-any.whl to 9.1.1
kicad-doc: Update kicad-doc.git to 10.0.4