### PR TITLE
kicad-10.0.5: Update libgit2, kicad, openblas and kicad-doc modules

### DIFF
--- a/kicad-doc.yml
+++ b/kicad-doc.yml
@@ -173,8 +173,8 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/kicad/services/kicad-doc.git
-        commit: ff59d8ecf799b8c11d61233738962ddc7f351f07
-        tag: 10.0.4
+        commit: a77c36a32bda3d3014a5dc4999e6702bec95b140
+        tag: 10.0.5
         x-checker-data:
           is-important: true
           type: git

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -231,8 +231,8 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: git
-        commit: f7164261c9bc0a7e0ebf767c584e5192810a8b24
-        tag: v1.9.4
+        commit: 26055f5af74ab1cf636d272e8a34315496d3f06f
+        tag: v1.9.6
         url: https://github.com/libgit2/libgit2
         x-checker-data:
           type: git
@@ -354,8 +354,8 @@ modules:
       - type: git
         dest: kicad-git
         url: https://gitlab.com/kicad/code/kicad.git
-        commit: f7414d419cae5df2d00e7eaacb16fc0e803799bc
-        tag: 10.0.4
+        commit: 18fb9289ff0efdca53c0352ed81a0973f0a6b58c
+        tag: 10.0.5
         x-checker-data:
           is-main-source: true
           type: git

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -35,8 +35,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/OpenMathLib/OpenBLAS
-        tag: v0.3.33
-        commit: 62bcfb0dc9f1cfa685fc04135c50e2780c303137
+        tag: v0.3.34
+        commit: e0166008be8e466242aa76b2ff75ce3f0fbf574a
         x-checker-data:
           type: git
           tag-pattern: ^(v[\d\.]+)$


### PR DESCRIPTION
libgit2: Update libgit2 to v1.9.6
kicad: Update kicad.git to 10.0.5
openblas: Update OpenBLAS to v0.3.34
kicad-doc: Update kicad-doc.git to 10.0.5